### PR TITLE
replace loaders by skeletons for smoother experience

### DIFF
--- a/src/components/Etablissement.vue
+++ b/src/components/Etablissement.vue
@@ -3,13 +3,15 @@
     <div class="container">
       <not-found v-if="isNotFound" />
       <server-error v-else-if="isError" />
-      <loader v-else-if="isEtablissementLoading" />
       <template v-else>
         <etablissement-header :searchId=searchId />
-        <!-- <etablissement-sirene v-if=haveSireneInfo />
-        <etablissement-rna v-if=haveRNAInfo :haveComponentTop=haveSireneInfo />
-        <etablissement-rnm v-if=haveRNMInfo /> -->
-        <etablissement-rncs v-if=haveRNCSInfo />
+        <blocks-skeleton v-if="!haveRNCSInfo"></blocks-skeleton>
+        <template v-else>
+          <!-- <etablissement-sirene v-if=haveSireneInfo />
+          <etablissement-rna v-if=haveRNAInfo :haveComponentTop=haveSireneInfo />
+          <etablissement-rnm v-if=haveRNMInfo /> -->
+          <etablissement-rncs v-if=haveRNCSInfo />
+        </template>
         <div class="company__extra">
           <div class="notification">
             <div>Ces informations sont issues du RNCS mis à jour le {{ RNCSUpdate }}.</div>
@@ -36,6 +38,8 @@ import EtablissementRNA from '@/components/etablissement/EtablissementRNA'
 import EtablissementRNM from '@/components/etablissement/EtablissementRNM'
 import EtablissementRNCS from '@/components/etablissement/EtablissementRNCS'
 
+import BlocksSkeleton from '@/components/etablissement/skeletons/BlocksSkeleton'
+
 export default {
   name: 'Etablissement',
   metaInfo () {
@@ -51,7 +55,8 @@ export default {
     'EtablissementSirene': EtablissementSirene,
     'EtablissementRna': EtablissementRNA,
     'EtablissementRnm': EtablissementRNM,
-    'EtablissementRncs': EtablissementRNCS
+    'EtablissementRncs': EtablissementRNCS,
+    'BlocksSkeleton': BlocksSkeleton
   },
   computed: {
     searchId () {
@@ -159,5 +164,9 @@ export default {
       margin-top: 1em;
     }
   }
+}
+
+.company__extra {
+  margin-top: 2em;
 }
 </style>

--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -1,8 +1,7 @@
 <template>
   <section class="section">
     <div class="container">
-      <loader v-if="resultsAreLoading"></loader>
-      <server-error v-else-if="serverError"></server-error>
+      <server-error v-if="serverError"></server-error>
       <template v-else>
         <results-sirene />
         <!-- <results-rna /> -->

--- a/src/components/etablissement/EtablissementHeader.vue
+++ b/src/components/etablissement/EtablissementHeader.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="company">
     <div class="company__main">
-      <div class="title__block">
+      <header-skeleton v-if="isEtablissementLoading"></header-skeleton>
+      <div class="title__block" v-else>
         <h2 v-if="haveSireneInfo">{{resultSirene.nom_raison_sociale | removeExtraChars}} <span class="company__siren">({{ resultSirene.siren }})</span></h2>
         <h2 v-if="haveOnlyRNAInfo">{{resultRNA.titre}} <span class="association__id">({{ resultRNA.id_association }})</span></h2>
 
@@ -21,7 +22,10 @@
         </div>
         <etablissement-sirene-children />
       </div>
-      <etablissement-map v-if=haveSireneInfo :positionEtablissement='coordinates' :etablissement='this.resultSirene'/>
+      <div class="map__dummy panel" v-if="isEtablissementLoading"></div>
+      <template v-else>
+        <etablissement-map v-if=haveSireneInfo :positionEtablissement='coordinates' :etablissement='this.resultSirene'/>
+      </template>
     </div>
   </div>
 </template>
@@ -30,15 +34,20 @@
 import Filters from '@/components/mixins/filters.js'
 import EtablissementSireneChildren from '@/components/etablissement/etablissementSirene/EtablissementSireneChildren'
 import EtablissementMap from '@/components/etablissement/EtablissementMap'
+import HeaderSkeleton from '@/components/etablissement/skeletons/HeaderSkeleton'
 
 export default {
   name: 'EtablissementHeader',
   props: ['searchId'],
   components: {
     'EtablissementSireneChildren': EtablissementSireneChildren,
-    'EtablissementMap': EtablissementMap
+    'EtablissementMap': EtablissementMap,
+    'HeaderSkeleton': HeaderSkeleton
   },
   computed: {
+    isEtablissementLoading () {
+      return this.$store.getters.isEtablissementLoading
+    },
     resultSirene () {
       return this.$store.getters.singlePageEtablissementSirene
     },
@@ -103,8 +112,6 @@ export default {
       padding: 0.5em 1em 0.6em;
       vertical-align: middle;
       margin-left: 0;
-      margin-right: 1em;
-      margin-top: 0.5em;
     }
   }
 
@@ -112,29 +119,22 @@ export default {
     margin: 0;
   }
 
-  .tabs {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-
-    @media screen and (max-width: $tablet) {
-      flex-direction: column;
-    }
-
-    margin: 2em 0;
-  }
-
   .subtitle {
     font-size: 1.25em;
   }
 
   .second__subtitle {
-    margin-top: 1em;
+    margin-top: 0.5em;
   }
 
   .company__siren,
   .second__subtitle {
     color: $color-darker-grey;
+  }
 
+  .map__dummy {
+    height: 350px;
+    width: 48%;
+    background-color: #f2eae2;
   }
 </style>

--- a/src/components/etablissement/__tests__/__snapshots__/EtablissementHeader.spec.js.snap
+++ b/src/components/etablissement/__tests__/__snapshots__/EtablissementHeader.spec.js.snap
@@ -7,64 +7,10 @@ exports[`EtablissementHeader.vue Snapshot testing It match the snapshot 1`] = `
   <div
     class="company__main"
   >
-    <div
-      class="title__block"
-    >
-      <h2>
-         
-        <span
-          class="company__siren"
-        >
-          ()
-        </span>
-      </h2>
-       
-      <!---->
-       
-      <div
-        class="subtitle"
-      >
-        <div>
-          
-        </div>
-         
-        <div>
-          
-        </div>
-      </div>
-       
-      <div
-        class="second__subtitle"
-      >
-         
-      </div>
-       
-      <!---->
-       
-      <div
-        class="company__buttons"
-      >
-        <a
-          class="button"
-          href="undefinedundefined/pdf"
-          title="Télécharger les données de cette entreprise au format PDF"
-        >
-          <img
-            alt=""
-            class="icon"
-            src="@/assets/img/download.svg"
-          />
-          
-          Version imprimable
-        
-        </a>
-      </div>
-       
-      <etablissementsirenechildren-stub />
-    </div>
+    <headerskeleton-stub />
      
-    <etablissementmap-stub
-      etablissement="[object Object]"
+    <div
+      class="map__dummy panel"
     />
   </div>
 </div>

--- a/src/components/etablissement/etablissementSirene/EtablissementSireneChildren.vue
+++ b/src/components/etablissement/etablissementSirene/EtablissementSireneChildren.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="company__panel">
-    <div v-if="isSiegeSocial" class="company__item">Cet établissement est le siège social</div>
-    <div v-else class="company__item">Le siège social de cet établissement est :
+    <p v-if="isSiegeSocial" class="company__item">Cet établissement est le siège social.</p>
+    <p v-else class="company__item">Le siège social de cet établissement est :
       <router-link class="company__item-link" :to="{ name: 'Etablissement', params: {searchId: resultSiegeSocial.siret}}">
         {{ resultSiegeSocial.nom_raison_sociale | removeExtraChars }} ({{ resultSiegeSocial.siret }})
       </router-link>
-    </div>
+    </p>
     <div v-if="haveChildrenEtablissements" class="company__item">
       <div class="company__children-summary">
         Cette entreprise possède {{ totalResultsOtherSirens }} {{ `établissement` | pluralizeDependingOn(this.totalResultsOtherSirens) }}<template v-if="thereAreMoreThanMaxChildren">
@@ -88,7 +88,7 @@ export default {
 
 <style lang="scss" scoped>
   .company__panel {
-    margin-top: 2em;
+    margin-top: 1.5em;
   }
 
   .company__item {

--- a/src/components/etablissement/skeletons/BlocksSkeleton.vue
+++ b/src/components/etablissement/skeletons/BlocksSkeleton.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="company__panel">
+    <div class="panel">
+      <h4 class="loading"></h4>
+      <div class="text__medium loading"></div>
+      <div class="text__long loading"></div>
+      <div class="text__long loading"></div>
+    </div>
+    <div class="panel">
+      <h4 class="loading"></h4>
+      <div class="text__medium loading"></div>
+      <div class="text__long loading"></div>
+      <div class="text__long loading"></div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'headerSkeleton'
+}
+</script>
+
+<style lang="scss" scoped>
+.company__panel {
+  display: flex;
+  justify-content: space-between;
+}
+
+.panel + .panel {
+  margin-left: 2em;
+  margin-top: 0;
+}
+
+.text__medium {
+  margin-top: 2em;
+  width: 60%;
+}
+
+.text__long {
+  width: 80%;
+  margin-top: 0.5em;
+}
+</style>

--- a/src/components/etablissement/skeletons/HeaderSkeleton.vue
+++ b/src/components/etablissement/skeletons/HeaderSkeleton.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="title__block">
+    <h2 class="loading"></h2>
+    <div class="subtitle loading"></div>
+    <div class="subtitle loading"></div>
+    <div class="second__subtitle loading"></div>
+    <div class="company__buttons">
+      <button class="button" title="Télécharger les données de cette entreprise au format PDF">
+        <img class="icon" src="@/assets/img/download.svg" alt="" />
+        Version imprimable
+      </button>
+    </div>
+    <div class="company__panel loading">
+      <div class="text__medium loading"></div>
+      <div class="text__long loading"></div>
+      <div class="text__medium loading"></div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'headerSkeleton'
+}
+</script>
+
+<style lang="scss" scoped>
+  .company__buttons {
+    margin-top: 1.5em;
+
+    .button {
+      padding: 0.5em 1em 0.6em;
+      vertical-align: middle;
+      margin-left: 0;
+    }
+  }
+
+  h2.loading {
+    width: 400px;
+    margin-bottom: 0.5em;
+  }
+
+  .subtitle.loading {
+    margin-top: 0.3em;
+    width: 150px;
+  }
+
+  .second__subtitle.loading {
+    margin-top: 1em;
+    width: 300px;
+  }
+
+  .text__medium.loading {
+    margin-top: 0.3em;
+    width: 300px;
+  }
+
+  .text__long.loading {
+    margin-top: 1.6em;
+    width: 150px;
+  }
+
+  .company__panel {
+    margin-top: 1.7em;
+  }
+</style>

--- a/src/components/results/ResultsSirene.vue
+++ b/src/components/results/ResultsSirene.vue
@@ -2,9 +2,10 @@
   <div>
     <h3>{{resultsNumberSentence}}</h3>
     <did-you-mean :api=api></did-you-mean>
-    <ul>
+    <results-skeleton v-if="resultsAreLoading"></results-skeleton>
+    <ul v-else>
       <li v-for="result in storedResultsEntreprises" :key="result.siret" class="panel">
-        <router-link tag="a" class="no_base_style" :to="{ name: 'Etablissement', params: {searchId: result['siret']}}">
+        <router-link class="no_base_style" :to="{ name: 'Etablissement', params: {searchId: result['siret']}}">
           <h4 class="title">{{result['nom_raison_sociale'] | capitalize | removeExtraChars}}</h4>
           <p>{{result['libelle_activite_principale_entreprise']}}</p>
           <p>{{result['code_postal']}} {{result['libelle_commune'] | capitalize}}</p>
@@ -19,6 +20,7 @@
 import DidYouMean from '@/components/results/ResultsDidYouMean'
 import Filters from '@/components/mixins/filters.js'
 import Formating from '@/components/mixins/formating.js'
+import ResultsSkeleton from '@/components/results/ResultsSkeleton'
 
 export default {
   name: 'ResultsSirene',
@@ -28,9 +30,13 @@ export default {
     }
   },
   components: {
-    'DidYouMean': DidYouMean
+    'DidYouMean': DidYouMean,
+    'ResultsSkeleton': ResultsSkeleton
   },
   computed: {
+    resultsAreLoading () {
+      return this.$store.getters.isFullTextLoading
+    },
     isSearchNotEmpty () {
       return this.$store.state.searchFullText.storedFullText !== ''
     },

--- a/src/components/results/ResultsSkeleton.vue
+++ b/src/components/results/ResultsSkeleton.vue
@@ -1,0 +1,47 @@
+<template>
+  <ul>
+    <li class="panel">
+      <div class="glow"></div>
+      <h2 class="loading"></h2>
+      <div class="text__long loading"></div>
+      <div class="text__medium loading"></div>
+    </li>
+    <li class="panel">
+      <div class="glow"></div>
+      <h2 class="loading"></h2>
+      <div class="text__long loading"></div>
+      <div class="text__medium loading"></div>
+    </li>
+    <li class="panel">
+      <div class="glow"></div>
+      <h2 class="loading"></h2>
+      <div class="text__long loading"></div>
+      <div class="text__medium loading"></div>
+    </li>
+  </ul>
+</template>
+
+<script>
+export default {
+  name: 'resultsSkeleton'
+}
+</script>
+
+<style lang="scss" scoped>
+h2.loading {
+  margin: 0;
+  width: 300px
+}
+
+.text__long {
+  margin-top: 1em;
+  width: 600px;
+}
+
+.text__medium {
+  margin-top: 1em;
+  width: 400px
+}
+
+
+</style>

--- a/src/style/_etablissement.scss
+++ b/src/style/_etablissement.scss
@@ -1,5 +1,5 @@
 .company__panel {
-  margin: 0 0 2em;
+  margin: 2em 0 0;
   width: 100%;
 }
 
@@ -66,6 +66,7 @@
 }
 
 .panel {
+  width: 100%;
   h4 {
     margin-top: 0;
   }

--- a/src/style/_skeletons.scss
+++ b/src/style/_skeletons.scss
@@ -1,0 +1,27 @@
+.loading {
+  background-color: $color-light-grey;
+  height: 1em;
+  border-radius: 3px;
+  max-width: 100%;
+}
+
+@keyframes flow {
+0% { left:-20px; }
+50% { left:30%; }
+100% { left:80%; }
+}
+
+.panel {
+  position: relative;
+  overflow: hidden;
+
+  .glow {
+    background: rgb(255,255,255); 
+    width: 150px; 
+    height: 100%; 
+    z-index: 999;
+    position: absolute;
+    animation: flow 2s linear infinite;
+    background: linear-gradient(to right, rgba(255,255,255,0) 30%,rgba(255,255,255,0.2) 50%,rgba(255,255,255,0) 80%);
+  }
+}

--- a/src/style/app.scss
+++ b/src/style/app.scss
@@ -2,4 +2,5 @@
 
 @import '_variables.scss';
 @import '_etablissement.scss';
+@import '_skeletons';
 @import 'main.scss';


### PR DESCRIPTION
Use skeletons to ease users from waiting feeling.
Also fixes margins on Etablissement page.

![image](https://user-images.githubusercontent.com/1301085/48003603-2f5a3480-e10f-11e8-8e2c-28cf3c94ed59.png)
