### PR TITLE
make whole result panels clickable

### DIFF
--- a/src/components/results/ResultsRNA.vue
+++ b/src/components/results/ResultsRNA.vue
@@ -3,8 +3,8 @@
     <h3>{{resultsNumberSentence}}</h3>
     <did-you-mean :api=api></did-you-mean>
     <ul>
-      <li v-for="result in storedResultsAssociations" :key="result.id" class="panel">
-        <router-link tag="a" class="no_base_style" :to="{ name: 'Etablissement', params: {searchId: result['id_association']}}">
+      <li v-for="result in storedResultsAssociations" :key="result.id">
+        <router-link class="panel" :to="{ name: 'Etablissement', params: {searchId: result['id_association']}}">
           <h4 class="title">{{result['titre'] | capitalize }}</h4>
           <p>{{ result['objet'] | truncate }}</p>
           <p>{{result['adresse_code_postal']}} {{result['adresse_libelle_commune'] | capitalize}}</p>
@@ -56,9 +56,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .no_base_style {
+  .panel {
     text-decoration: none;
     color: $color-black;
+    display: block;
   }
 
   p {
@@ -73,6 +74,10 @@ export default {
     li:hover {
       background-color: $color-lightest-grey;
     }
+  }
+
+  li + li {
+    margin-top: 2em;
   }
 </style>
 

--- a/src/components/results/ResultsSirene.vue
+++ b/src/components/results/ResultsSirene.vue
@@ -4,8 +4,8 @@
     <did-you-mean :api=api></did-you-mean>
     <results-skeleton v-if="resultsAreLoading"></results-skeleton>
     <ul v-else>
-      <li v-for="result in storedResultsEntreprises" :key="result.siret" class="panel">
-        <router-link class="no_base_style" :to="{ name: 'Etablissement', params: {searchId: result['siret']}}">
+      <li v-for="result in storedResultsEntreprises" :key="result.siret">
+        <router-link class="panel" :to="{ name: 'Etablissement', params: {searchId: result['siret']}}">
           <h4 class="title">{{result['nom_raison_sociale'] | capitalize | removeExtraChars}}</h4>
           <p>{{result['libelle_activite_principale_entreprise']}}</p>
           <p>{{result['code_postal']}} {{result['libelle_commune'] | capitalize}}</p>
@@ -74,7 +74,8 @@ export default {
     font-family: "Evolventa", "Trebuchet MS", sans-serif;
   }
 
-  .no_base_style {
+  .panel {
+    display: block;
     text-decoration: none;
     color: $color-black;
   }
@@ -91,6 +92,10 @@ export default {
     li:hover {
       background-color: $color-lightest-grey;
     }
+  }
+
+  li + li {
+    margin-top: 2em;
   }
 </style>
 

--- a/src/components/results/ResultsSkeleton.vue
+++ b/src/components/results/ResultsSkeleton.vue
@@ -2,7 +2,7 @@
   <ul>
     <li class="panel">
       <div class="glow"></div>
-      <h2 class="loading"></h2>
+      <h4 class="loading"></h4>
       <div class="text__long loading"></div>
       <div class="text__medium loading"></div>
     </li>
@@ -28,7 +28,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-h2.loading {
+h4.loading {
   margin: 0;
   width: 300px
 }


### PR DESCRIPTION
Transfer `.panel` class from `li` to `a` because of padding.

Fixes #193 