### PR TITLE
Fiche d'identité entreprise

### DIFF
--- a/src/components/etablissement/EntrepriseIdentityHeader.vue
+++ b/src/components/etablissement/EntrepriseIdentityHeader.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="company">
+    <div class="company__main">
+      <header-skeleton v-if="isEtablissementLoading"></header-skeleton>
+      <div class="title__block" v-else>
+        <h2 v-if="haveSireneInfo">{{resultSirene.nom_raison_sociale | removeExtraChars}} <span class="company__siren">({{ resultSirene.siren }})</span></h2>
+
+        <template v-if="haveSireneInfo">
+          <div class="subtitle">
+            <div>{{ resultSirene.l4_normalisee }}</div>
+            <div>{{ resultSirene.l6_normalisee }}</div>
+          </div>
+          <div class="second__subtitle"> {{ resultSirene.libelle_activite_principale_entreprise }}</div>
+        </template>
+        <div class="company__buttons">
+          <a class="button" v-bind:href="dataRequestPDF" title="Télécharger les données de cette entreprise au format PDF">
+            <img class="icon" src="@/assets/img/download.svg" alt="" />
+            Version imprimable
+          </a>
+        </div>
+        <etablissement-sirene-children v-if=haveSireneInfo />
+      </div>
+      <div v-if=isEtablissementLoading class="map__dummy panel"></div>
+      <template v-else>
+        <etablissement-map v-if=haveSireneInfo :positionEtablissement='coordinates' :etablissement='this.resultSirene'/>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script>
+import Filters from '@/components/mixins/filters.js'
+import EtablissementSireneChildren from '@/components/etablissement/etablissementSirene/EtablissementSireneChildren'
+import EtablissementMap from '@/components/etablissement/EtablissementMap'
+import HeaderSkeleton from '@/components/etablissement/skeletons/HeaderSkeleton'
+
+export default {
+  name: 'EtablissementHeader',
+  props: ['searchId'],
+  components: {
+    'EtablissementSireneChildren': EtablissementSireneChildren,
+    'EtablissementMap': EtablissementMap,
+    'HeaderSkeleton': HeaderSkeleton
+  },
+  computed: {
+    isEtablissementLoading () {
+      return this.$store.getters.mainAPISLoading
+    },
+    resultSirene () {
+      return this.$store.getters.singlePageEtablissementSirene
+    },
+    haveSireneInfo () {
+      if (this.$store.getters.sireneAvailable) {
+        return true
+      }
+    },
+    coordinates () {
+      if (this.resultSirene && this.resultSirene.longitude && this.resultSirene.latitude) {
+        return [this.resultSirene.longitude, this.resultSirene.latitude]
+      }
+      return null
+    },
+    dataRequestPDF () {
+      return `${process.env.BASE_ADDRESS_RNCS}${this.searchId}/pdf`
+    },
+  },
+  mixins: [Filters]
+}
+</script>
+
+<style lang="scss" scoped>
+  .company__main {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  #map {
+    margin-left: 2em;
+  }
+
+  @media (max-width: $desktop) {
+    .company__main {
+      flex-direction: column;
+    }
+
+    #map {
+      margin-left: 0;
+    }
+  }
+
+  .company__buttons {
+    margin-top: 1.5em;
+
+    .button {
+      padding: 0.5em 1em 0.6em;
+      vertical-align: middle;
+      margin-left: 0;
+    }
+  }
+
+  h2 {
+    margin: 0;
+  }
+
+  .subtitle {
+    font-size: 1.25em;
+  }
+
+  .second__subtitle {
+    margin-top: 0.5em;
+  }
+
+  .company__siren,
+  .second__subtitle {
+    color: $color-darker-grey;
+  }
+
+  .map__dummy {
+    height: 350px;
+    width: 48%;
+    background-color: #f2eae2;
+  }
+</style>

--- a/src/components/etablissement/EntrepriseIdentityRNCS.vue
+++ b/src/components/etablissement/EntrepriseIdentityRNCS.vue
@@ -4,7 +4,7 @@
       <not-found v-if="isNotFound" />
       <server-error v-else-if="isError" />
 
-      <etablissement-header :searchId=searchId />
+      <entreprise-identity-header :searchId=searchId />
       <blocks-skeleton v-if="RNCSLoading"/>
       <etablissement-rncs v-else-if="haveRNCSInfo"/>
       <div v-if=haveRNCSInfo class="company__extra">
@@ -25,7 +25,7 @@ import Filters from '@/components/mixins/filters'
 import Loader from '@/components/modules/Loader'
 import ServerError from '@/components/modules/ServerError'
 import NotFound from '@/components/etablissement/EtablissementNotFound'
-import EtablissementHeader from '@/components/etablissement/EtablissementHeader'
+import EntrepriseIdentityHeader from '@/components/etablissement/EntrepriseIdentityHeader'
 import EtablissementRNCS from '@/components/etablissement/EtablissementRNCS'
 import BlocksSkeleton from '@/components/etablissement/skeletons/BlocksSkeleton'
 
@@ -40,7 +40,7 @@ export default {
     'Loader': Loader,
     'ServerError': ServerError,
     'NotFound': NotFound,
-    'EtablissementHeader': EtablissementHeader,
+    'EntrepriseIdentityHeader': EntrepriseIdentityHeader,
     'EtablissementRncs': EtablissementRNCS,
     'BlocksSkeleton': BlocksSkeleton
   },

--- a/src/components/etablissement/EntrepriseIdentityRNCS.vue
+++ b/src/components/etablissement/EntrepriseIdentityRNCS.vue
@@ -99,12 +99,12 @@ export default {
     this.$store.commit('setStoredSuggestions', '')
   },
   created () {
-    this.$store.dispatch('executeSearchEtablissement', this.$route.params.searchId)
+    this.$store.dispatch('executeSearchRNCS', this.$route.params.searchId)
   },
   mixins: [Filters],
   watch: {
     '$route' (to, from) {
-      this.$store.dispatch('executeSearchEtablissement', this.$route.params.searchId)
+      this.$store.dispatch('executeSearchRNCS', this.$route.params.searchId)
     }
   }
 }

--- a/src/components/etablissement/EntrepriseIdentityRNCS.vue
+++ b/src/components/etablissement/EntrepriseIdentityRNCS.vue
@@ -1,0 +1,142 @@
+<template>
+  <section class="section">
+    <div class="container">
+      <not-found v-if="isNotFound" />
+      <server-error v-else-if="isError" />
+
+      <etablissement-header :searchId=searchId />
+      <blocks-skeleton v-if="RNCSLoading"/>
+      <etablissement-rncs v-else-if="haveRNCSInfo"/>
+      <div v-if=haveRNCSInfo class="company__extra">
+        <div class="notification">
+          <div>Ces informations sont issues du RNCS mis à jour le {{ RNCSUpdate }}.</div>
+          <a class="button-outline secondary" target="_blank" v-bind:href="dataRequestURL" title="Accéder aux données brutes de cette entreprise">
+            <img class="icon" src="@/assets/img/json.svg" alt="" />
+            Accéder aux données JSON
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+import Filters from '@/components/mixins/filters'
+import Loader from '@/components/modules/Loader'
+import ServerError from '@/components/modules/ServerError'
+import NotFound from '@/components/etablissement/EtablissementNotFound'
+import EtablissementHeader from '@/components/etablissement/EtablissementHeader'
+import EtablissementRNCS from '@/components/etablissement/EtablissementRNCS'
+import BlocksSkeleton from '@/components/etablissement/skeletons/BlocksSkeleton'
+
+export default {
+  name: 'EntrepriseIdentityRNCS',
+  metaInfo () {
+    return {
+      title: this.titleEtablissement()
+    }
+  },
+  components: {
+    'Loader': Loader,
+    'ServerError': ServerError,
+    'NotFound': NotFound,
+    'EtablissementHeader': EtablissementHeader,
+    'EtablissementRncs': EtablissementRNCS,
+    'BlocksSkeleton': BlocksSkeleton
+  },
+  computed: {
+    searchId () {
+      return this.$route.params.searchId
+    },
+    isNotFound () {
+      return this.$store.getters.mainAPISNotFound
+    },
+    isError () {
+      return this.$store.getters.mainAPISError
+    },
+    haveSireneInfo () {
+      return this.$store.getters.sireneAvailable
+    },
+    haveRNCSInfo () {
+      return this.$store.getters.RNCSAvailable
+    },
+    resultSirene () {
+      if (this.haveSireneInfo) {
+        return this.$store.getters.singlePageEtablissementSirene
+      }
+      return null
+    },
+    dataRequestURL () {
+      if (this.resultSirene) {
+        return `${process.env.BASE_ADDRESS_RNCS}${this.resultSirene.siren}`
+      }
+      return null
+    },
+    RNCSUpdate () {
+      if (this.$store.getters.RNCSData) {
+        return Filters.filters.frenchDateFormat(this.$store.getters.RNCSData.updated_at)
+      }
+      return null
+    },
+    RNCSLoading () {
+      return this.$store.getters.additionalAPILoading('RNCS')
+    },
+  },
+  methods: {
+    titleEtablissement () {
+      if (this.haveSireneInfo) {
+        return `Etablissement ${
+          Filters.filters.removeExtraChars(this.$store.getters.singlePageEtablissementSirene.nom_raison_sociale
+        )}`
+      } else if (this.haveRNAInfo) {
+        return `Association ${this.$store.getters.singlePageEtablissementRNA.titre}`
+      } else {
+        return 'Etablissement'
+      }
+    }
+  },
+  beforeCreate () {
+    this.$store.commit('setStoredSuggestions', '')
+  },
+  created () {
+    this.$store.dispatch('executeSearchEtablissement', this.$route.params.searchId)
+  },
+  mixins: [Filters],
+  watch: {
+    '$route' (to, from) {
+      this.$store.dispatch('executeSearchEtablissement', this.$route.params.searchId)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.notification {
+  border-color: $color-grey;
+  background-color: $color-lightest-grey;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  .button-outline {
+    flex-shrink: 0;
+    margin-left: 1em;
+  }
+}
+
+@media (max-width: $tablet) {
+  .notification {
+    flex-direction: column;
+
+    .button-outline {
+      margin-left: 0;
+      margin-top: 1em;
+    }
+  }
+}
+
+.company__extra {
+  margin-top: 2em;
+}
+</style>

--- a/src/components/etablissement/EtablissementHeader.vue
+++ b/src/components/etablissement/EtablissementHeader.vue
@@ -21,6 +21,8 @@
           </a>
         </div>
         <etablissement-sirene-children v-if=haveSireneInfo />
+
+        <router-link :to="{ name: 'RNCS', params: {searchId: resultSirene.siren}}"> Fiche d'immatriculation au RNCS </router-link>
       </div>
       <div v-if=isEtablissementLoading class="map__dummy panel"></div>
       <template v-else>

--- a/src/components/etablissement/__tests__/__snapshots__/EtablissementHeader.spec.js.snap
+++ b/src/components/etablissement/__tests__/__snapshots__/EtablissementHeader.spec.js.snap
@@ -44,6 +44,12 @@ exports[`EtablissementHeader.vue Snapshot testing It match the snapshot 1`] = `
       <!---->
        
       <etablissementsirenechildren-stub />
+       
+      <router-link
+        to="[object Object]"
+      >
+         Fiche d'immatriculation au RNCS 
+      </router-link>
     </div>
      
     <etablissementmap-stub

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -65,7 +65,8 @@ export default {
 
       // Start search except if input is empty
       if (this.isSearchNotEmpty) {
-        this.requestSearch()
+        if (this.currentPageIsRNCS) this.requestSearchRNCS()
+        else this.requestSearch()
       }
     },
     requestSearch: function () {
@@ -74,6 +75,17 @@ export default {
       if (natureSearchId) {
         this.fullText = this.removeSeparators(this.fullText)
         this.$router.push({ path: `/etablissement/${this.fullText}` })
+      } else {
+        this.requestFullTextSearch()
+      }
+      this.$store.commit('clearFullTextResults')
+    },
+    requestSearchRNCS: function () {
+      const natureSearchId = this.analyzeSearchId(this.fullText)
+
+      if (natureSearchId) {
+        this.fullText = this.removeSeparators(this.fullText)
+        this.$router.push({ path: `/rncs/${this.fullText}` })
       } else {
         this.requestFullTextSearch()
       }
@@ -89,6 +101,9 @@ export default {
       }
       this.$store.dispatch('requestSearchFullText')
       this.suggestCount = -1
+    },
+    currentPageIsRNCS: function () {
+      return this.$route.name == 'RNCS'
     }
   },
   beforeDestroy() {

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -65,8 +65,7 @@ export default {
 
       // Start search except if input is empty
       if (this.isSearchNotEmpty) {
-        if (this.currentPageIsRNCS) this.requestSearchRNCS()
-        else this.requestSearch()
+        this.requestSearch()
       }
     },
     requestSearch: function () {
@@ -75,17 +74,6 @@ export default {
       if (natureSearchId) {
         this.fullText = this.removeSeparators(this.fullText)
         this.$router.push({ path: `/etablissement/${this.fullText}` })
-      } else {
-        this.requestFullTextSearch()
-      }
-      this.$store.commit('clearFullTextResults')
-    },
-    requestSearchRNCS: function () {
-      const natureSearchId = this.analyzeSearchId(this.fullText)
-
-      if (natureSearchId) {
-        this.fullText = this.removeSeparators(this.fullText)
-        this.$router.push({ path: `/rncs/${this.fullText}` })
       } else {
         this.requestFullTextSearch()
       }
@@ -101,9 +89,6 @@ export default {
       }
       this.$store.dispatch('requestSearchFullText')
       this.suggestCount = -1
-    },
-    currentPageIsRNCS: function () {
-      return this.$route.name == 'RNCS'
     }
   },
   beforeDestroy() {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,7 @@ import ApiDocSirene from '@/components/apiDoc/ApiDocSirene'
 import ApiDocRNA from '@/components/apiDoc/ApiDocRNA'
 import ApiDocRNCS from '@/components/apiDoc/ApiDocRNCS'
 import CodesNAF from '@/components/apiDoc/apiDocSirene/CodesNAF'
+import EntrepriseIdentityRNCS from '@/components/etablissement/EntrepriseIdentityRNCS.vue'
 
 Vue.use(Router)
 Vue.use(Meta)
@@ -24,6 +25,11 @@ export default new Router({
       path: '/search?*',
       name: 'Search',
       component: Results
+    },
+    {
+      path: '/rncs/:searchId',
+      name: 'RNCS',
+      component: EntrepriseIdentityRNCS
     },
     {
       path: '/search',

--- a/src/store/modules/searchEtablissement.js
+++ b/src/store/modules/searchEtablissement.js
@@ -16,6 +16,30 @@ const state = {
 }
 
 const actions = {
+  async executeSearchRNCS(dispatch, searchId) {
+    await store.dispatch('resetApplicationState')
+    const natureSearchId = regExps.methods.analyzeSearchId(searchId)
+    const api = 'RNCS'
+
+    switch (natureSearchId) {
+      case 'SIRET':
+        break
+      case 'SIREN':
+        await store.dispatch('sendAPIRequest', process.env.BASE_ADDRESS_RNCS + searchId)
+        .then(response => {
+          store.dispatch('setResponseAdditionalInfo', {response: response, api: api})
+        })
+        .catch(notFound => {
+          store.dispatch('setResponseAdditionalInfo', {response: notFound, api: api})
+        })
+        .finally(() => store.commit('setLoadingAdditionalAPI', { value: false, endpoint: api }))
+        break
+      default:
+        store.commit('setStatusMainAPI', { value: 404, endpoint: 'ALL' })
+    }
+    store.commit('setLoadingMainAPI', { value: false, endpoint: 'ALL' })
+  },
+
   async executeSearchEtablissement(dispatch, searchId) {
     await store.dispatch('resetApplicationState')
     const natureSearchId = regExps.methods.analyzeSearchId(searchId)


### PR DESCRIPTION
## Contenu de la PR 
* Affichage de la fiche d'identité d'entreprise issue du RNCS (nouveau composant Vue *EntrepriseIdentityRNCS*). Il s'agit de la page d'information qui était accessible pour la démo, ou lorsque que le front était préalablement *build* pour l'environnement RNCS.
* Nouvelle route */rncs/:siren* qui pointe vers la fiche d'identité entreprise
* Un lien depuis la page */etablissement* vers la fiche d'identité entreprise
* La fiche d'identité entreprise est exclusivement peuplée via les API RNCS (aucun appel intermédiaire aux API de l'INSEE)

## Comment faire la review ?
Dans son ensemble, il n'y a pas beaucoup de modifications et les retours en arrière dans les développements rendent caduques l'approche commit par commit. 

Ce n'est pas forcément le meilleur développement possible. J'ai essayer de faire au plus simple pour intégrer mes modifications dans le code actuel, avec le moins d'impact possible.

Il y a des composants dupliqués : *Etablissement* en *EntrepriseIdentityRNCS* et *EtablissementHeader* en *EntrepriseIdentityHeader*. Personnellement je pense que des "doublons" sont plus légitimes ici que les multiples `v-if` et sont le signe d'un refactor plus profond à faire à terme.