### PR TITLE
[RNCS] Display db date & error handling

### DIFF
--- a/config/dev.env.js
+++ b/config/dev.env.js
@@ -5,7 +5,7 @@ module.exports = merge(prodEnv, {
   NODE_ENV: '"development"',
 
   // comment out this value to test RNCS / not RNCS
-  // DISPLAY_RNCS: true,
+  DISPLAY_RNCS: true,
 
   ENDPOINTS: require('./endpoints.js'),
 
@@ -19,6 +19,6 @@ module.exports = merge(prodEnv, {
   BASE_ADDRESS_RNA_SIRET: '"http://localhost:3001/v1/siret/"',
   BASE_ADDRESS_RNA_ID_ASSOCIATION: '"http://localhost:3001/v1/id/"',
 
-  BASE_ADDRESS_RNCS: '"http://localhost:3000/infos_identite_entreprise/"',
+  BASE_ADDRESS_RNCS: '"http://localhost:3002/infos_identite_entreprise/"',
   BASE_ADDRESS_RNM: '"https://api-rnm.artisanat.fr/api/entreprise/"'
 })

--- a/src/components/Etablissement.vue
+++ b/src/components/Etablissement.vue
@@ -9,15 +9,6 @@
         <etablissement-header :searchId=searchId />
         <blocks-skeleton v-if="RNCSLoading"/>
         <etablissement-rncs v-else-if="haveRNCSInfo"/>
-        <div v-if=haveRNCSInfo class="company__extra">
-          <div class="notification">
-            <div>Ces informations sont issues du RNCS mis à jour le {{ RNCSUpdate }}.</div>
-            <a class="button-outline secondary" target="_blank" v-bind:href="dataRequestURL" title="Accéder aux données brutes de cette entreprise">
-              <img class="icon" src="@/assets/img/json.svg" alt="" />
-              Accéder aux données JSON
-            </a>
-          </div>
-        </div>
       </template>
 
       <template v-else>

--- a/src/components/Etablissement.vue
+++ b/src/components/Etablissement.vue
@@ -1,17 +1,28 @@
 <template>
   <section class="section">
     <div class="container">
-      <not-found v-if="isNotFound" />
-      <server-error v-else-if="isError" />
+      <server-error v-if="isError" />
 
       <!-- Temporary section here to display RNCS Only -->
-      <template v-else-if=displayingOnlyRNCS>
-        <etablissement-header :searchId=searchId />
+      <template v-if=displayingOnlyRNCS>
+        <div class="notification error" v-if="AdditionalAPIError">Erreur du service RNCS : {{ APIError }}</div>
+        <entreprise-identity-header :searchId=searchId />
         <blocks-skeleton v-if="RNCSLoading"/>
         <etablissement-rncs v-else-if="haveRNCSInfo"/>
+        <div v-if=haveRNCSInfo class="company__extra">
+          <div class="notification grey">
+            <div>Ces informations sont issues du RNCS mis à jour le {{ RNCSUpdate }}.</div>
+            <a class="button-outline secondary" target="_blank" v-bind:href="dataRequestURL" title="Accéder aux données brutes de cette entreprise">
+              <img class="icon" src="@/assets/img/json.svg" alt="" />
+              Accéder aux données JSON
+            </a>
+          </div>
+        </div>
       </template>
+      <!-- End temporary -->
 
       <template v-else>
+        <not-found v-if="isNotFound" />
         <etablissement-header :searchId=searchId />
         <blocks-skeleton v-if="mainAPISLoading"/>
         <etablissement-sirene v-if=haveSireneInfo />
@@ -32,6 +43,7 @@ import EtablissementSirene from '@/components/etablissement/EtablissementSirene'
 import EtablissementRNA from '@/components/etablissement/EtablissementRNA'
 import EtablissementRNM from '@/components/etablissement/EtablissementRNM'
 import EtablissementRNCS from '@/components/etablissement/EtablissementRNCS'
+import EntrepriseIdentityHeader from '@/components/etablissement/EntrepriseIdentityHeader'
 import BlocksSkeleton from '@/components/etablissement/skeletons/BlocksSkeleton'
 
 export default {
@@ -50,6 +62,7 @@ export default {
     'EtablissementRna': EtablissementRNA,
     'EtablissementRnm': EtablissementRNM,
     'EtablissementRncs': EtablissementRNCS,
+    'EntrepriseIdentityHeader': EntrepriseIdentityHeader,
     'BlocksSkeleton': BlocksSkeleton
   },
   computed: {
@@ -101,11 +114,18 @@ export default {
     mainAPISLoading () {
       return this.$store.getters.mainAPISLoading
     },
-    // Temporary methods for displaying RNCS-only
+    // Begin : Temporary methods for displaying RNCS-only
     displayingOnlyRNCS () {
       if (process.env.DISPLAY_RNCS)
         return true
+    },
+    AdditionalAPIError () {
+      return this.$store.getters.additionalAPINotFound('RNCS')
+    },
+    APIError () {
+      return this.$store.getters.RNCSError
     }
+    // End
   },
   methods: {
     titleEtablissement () {
@@ -134,9 +154,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.grey {
+  background-color: $color-lightest-grey;
+}
 .notification {
   border-color: $color-grey;
-  background-color: $color-lightest-grey;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/components/Etablissement.vue
+++ b/src/components/Etablissement.vue
@@ -84,7 +84,7 @@ export default {
       return this.$store.getters.RNMAvailable
     },
     haveRNCSInfo () {
-      return this.$store.getters.RNCSAvailable
+      return this.$store.getters.additionalAPIAvailable('RNCS')
     },
     resultSirene () {
       if (this.haveSireneInfo) {
@@ -100,7 +100,7 @@ export default {
     },
     RNCSUpdate () {
       if (this.$store.getters.RNCSData) {
-        return Filters.filters.frenchDateFormat(this.$store.getters.RNCSData.updated_at)
+        return Filters.filters.frenchDateFormat(this.$store.getters.RNCSData.db_current_date)
       }
       return null
     },

--- a/src/components/etablissement/EntrepriseIdentityHeader.vue
+++ b/src/components/etablissement/EntrepriseIdentityHeader.vue
@@ -12,6 +12,7 @@
           </div>
           <div class="second__subtitle"> {{ resultSirene.libelle_activite_principale_entreprise }}</div>
         </template>
+
         <div class="company__buttons" v-if="haveRNCSInfo">
           <a class="button" v-bind:href="dataRequestPDF" title="Télécharger les données de cette entreprise au format PDF">
             <img class="icon" src="@/assets/img/download.svg" alt="" />
@@ -20,6 +21,7 @@
         </div>
         <etablissement-sirene-children v-if=haveSireneInfo />
       </div>
+
       <div v-if=isEtablissementLoading class="map__dummy panel"></div>
       <template v-else>
         <etablissement-map v-if=haveSireneInfo :positionEtablissement='coordinates' :etablissement='this.resultSirene'/>

--- a/src/components/etablissement/EntrepriseIdentityHeader.vue
+++ b/src/components/etablissement/EntrepriseIdentityHeader.vue
@@ -12,7 +12,7 @@
           </div>
           <div class="second__subtitle"> {{ resultSirene.libelle_activite_principale_entreprise }}</div>
         </template>
-        <div class="company__buttons">
+        <div class="company__buttons" v-if="haveRNCSInfo">
           <a class="button" v-bind:href="dataRequestPDF" title="Télécharger les données de cette entreprise au format PDF">
             <img class="icon" src="@/assets/img/download.svg" alt="" />
             Version imprimable
@@ -48,6 +48,9 @@ export default {
     },
     resultSirene () {
       return this.$store.getters.singlePageEtablissementSirene
+    },
+    haveRNCSInfo () {
+      return this.$store.getters.additionalAPIAvailable('RNCS')
     },
     haveSireneInfo () {
       if (this.$store.getters.sireneAvailable) {

--- a/src/components/etablissement/EntrepriseIdentityRNCS.vue
+++ b/src/components/etablissement/EntrepriseIdentityRNCS.vue
@@ -1,14 +1,15 @@
 <template>
   <section class="section">
     <div class="container">
-      <not-found v-if="isNotFound" />
-      <server-error v-else-if="isError" />
+      <server-error v-if="isError" />
 
+      <div class="notification error" v-if="AdditionalAPIError">Erreur du service RNCS : {{ APIError }}</div>
       <entreprise-identity-header :searchId=searchId />
+      <etablissement-header :searchId=searchId />
       <blocks-skeleton v-if="RNCSLoading"/>
       <etablissement-rncs v-else-if="haveRNCSInfo"/>
       <div v-if=haveRNCSInfo class="company__extra">
-        <div class="notification">
+        <div class="notification grey">
           <div>Ces informations sont issues du RNCS mis à jour le {{ RNCSUpdate }}.</div>
           <a class="button-outline secondary" target="_blank" v-bind:href="dataRequestURL" title="Accéder aux données brutes de cette entreprise">
             <img class="icon" src="@/assets/img/json.svg" alt="" />
@@ -81,15 +82,19 @@ export default {
     RNCSLoading () {
       return this.$store.getters.additionalAPILoading('RNCS')
     },
+    AdditionalAPIError () {
+      return this.$store.getters.additionalAPINotFound('RNCS')
+    },
+    APIError () {
+      return this.$store.getters.RNCSError
+    }
   },
   methods: {
     titleEtablissement () {
       if (this.haveSireneInfo) {
-        return `Etablissement ${
-          Filters.filters.removeExtraChars(this.$store.getters.singlePageEtablissementSirene.nom_raison_sociale
-        )}`
+        return Filters.filters.removeExtraChars(this.$store.getters.singlePageEtablissementSirene.nom_raison_sociale)
       } else if (this.haveRNAInfo) {
-        return `Association ${this.$store.getters.singlePageEtablissementRNA.titre}`
+        return this.$store.getters.singlePageEtablissementRNA.titre
       } else {
         return 'Etablissement'
       }
@@ -111,9 +116,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.grey {
+  background-color: $color-lightest-grey;
+}
 .notification {
   border-color: $color-grey;
-  background-color: $color-lightest-grey;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/components/etablissement/EntrepriseIdentityRNCS.vue
+++ b/src/components/etablissement/EntrepriseIdentityRNCS.vue
@@ -49,16 +49,16 @@ export default {
       return this.$route.params.searchId
     },
     isNotFound () {
-      return this.$store.getters.mainAPISNotFound
+      return this.$store.getters.mainAPISNotFound || this.$store.getters.additionalAPINotFound('RNCS')
     },
     isError () {
-      return this.$store.getters.mainAPISError
+      return this.$store.getters.mainAPISError || this.$store.getters.additionalAPIError('RNCS')
     },
     haveSireneInfo () {
       return this.$store.getters.sireneAvailable
     },
     haveRNCSInfo () {
-      return this.$store.getters.RNCSAvailable
+      return this.$store.getters.additionalAPIAvailable('RNCS')
     },
     resultSirene () {
       if (this.haveSireneInfo) {
@@ -74,7 +74,7 @@ export default {
     },
     RNCSUpdate () {
       if (this.$store.getters.RNCSData) {
-        return Filters.filters.frenchDateFormat(this.$store.getters.RNCSData.updated_at)
+        return Filters.filters.frenchDateFormat(this.$store.getters.RNCSData.db_current_date)
       }
       return null
     },

--- a/src/components/etablissement/EtablissementHeader.vue
+++ b/src/components/etablissement/EtablissementHeader.vue
@@ -14,12 +14,6 @@
           <div class="second__subtitle"> {{ resultSirene.libelle_activite_principale_entreprise }}</div>
         </template>
         <div v-if="haveOnlyRNAInfo" class="second__subtitle"> {{ resultRNA.titre_court}}</div>
-        <div v-if=displayingOnlyRNCS class="company__buttons">
-          <a class="button" v-bind:href="dataRequestPDF" title="Télécharger les données de cette entreprise au format PDF">
-            <img class="icon" src="@/assets/img/download.svg" alt="" />
-            Version imprimable
-          </a>
-        </div>
         <etablissement-sirene-children v-if=haveSireneInfo />
 
         <router-link v-if=displayRNCS :to="{ name: 'RNCS', params: {searchId: resultSirene.siren}}"> Fiche d'immatriculation au RNCS </router-link>

--- a/src/components/etablissement/EtablissementHeader.vue
+++ b/src/components/etablissement/EtablissementHeader.vue
@@ -15,8 +15,6 @@
         </template>
         <div v-if="haveOnlyRNAInfo" class="second__subtitle"> {{ resultRNA.titre_court}}</div>
         <etablissement-sirene-children v-if=haveSireneInfo />
-
-        <router-link v-if=displayRNCS :to="{ name: 'RNCS', params: {searchId: resultSirene.siren}}"> Fiche d'immatriculation au RNCS </router-link>
       </div>
       <div v-if=isEtablissementLoading class="map__dummy panel"></div>
       <template v-else>
@@ -41,10 +39,6 @@ export default {
     'HeaderSkeleton': HeaderSkeleton
   },
   computed: {
-    displayRNCS () {
-      if (process.env.DISPLAY_RNCS)
-        return true
-    },
     isEtablissementLoading () {
       return this.$store.getters.mainAPISLoading
     },
@@ -72,17 +66,6 @@ export default {
         return [this.resultSirene.longitude, this.resultSirene.latitude]
       }
       return null
-    },
-    dataRequestPDF () {
-      if (this.resultSirene) {
-        return `${process.env.BASE_ADDRESS_RNCS}${this.resultSirene.siren}/pdf`
-      }
-      return null
-    },
-    // Temporary methods for displaying RNCS-only
-    displayingOnlyRNCS () {
-      if (process.env.DISPLAY_RNCS)
-        return true
     }
   },
   mixins: [Filters]

--- a/src/components/etablissement/__tests__/__snapshots__/EtablissementHeader.spec.js.snap
+++ b/src/components/etablissement/__tests__/__snapshots__/EtablissementHeader.spec.js.snap
@@ -41,11 +41,7 @@ exports[`EtablissementHeader.vue Snapshot testing It match the snapshot 1`] = `
        
       <!---->
        
-      <!---->
-       
       <etablissementsirenechildren-stub />
-       
-      <!---->
     </div>
      
     <etablissementmap-stub

--- a/src/components/etablissement/skeletons/HeaderSkeleton.vue
+++ b/src/components/etablissement/skeletons/HeaderSkeleton.vue
@@ -4,12 +4,6 @@
     <div class="subtitle loading"></div>
     <div class="subtitle loading"></div>
     <div class="second__subtitle loading"></div>
-    <div class="company__buttons" v-if=displayingOnlyRNCS>
-      <button class="button" title="Télécharger les données de cette entreprise au format PDF">
-        <img class="icon" src="@/assets/img/download.svg" alt="" />
-        Version imprimable
-      </button>
-    </div>
     <div class="company__panel loading">
       <div class="text__medium loading"></div>
       <div class="text__long loading"></div>
@@ -21,14 +15,7 @@
 <script>
 
 export default {
-  name: 'headerSkeleton',
-  computed: {
-    // Temporary methods for displaying RNCS-only
-    displayingOnlyRNCS () {
-      if (process.env.DISPLAY_RNCS)
-        return true
-    }
-  }
+  name: 'headerSkeleton'
 }
 </script>
 

--- a/src/store/modules/application.js
+++ b/src/store/modules/application.js
@@ -18,13 +18,13 @@ const notFoundCodes = [400, 404, 422]
 const state = {
   isLoading: {
     fullText: mapValues(endpoints.fullText, () => false),
-    etablissementMain:  mapValues(endpoints.etablissementMain, () => false),
-    etablissementAdditional:  mapValues(endpoints.etablissementAdditional, () => false)
+    etablissementMain: mapValues(endpoints.etablissementMain, () => false),
+    etablissementAdditional: mapValues(endpoints.etablissementAdditional, () => false)
   },
   status: {
     fullText: mapValues(endpoints.fullText, () => null),
-    etablissementMain:  mapValues(endpoints.etablissementMain, () => null),
-    etablissementAdditional:  mapValues(endpoints.etablissementAdditional, () => null)
+    etablissementMain: mapValues(endpoints.etablissementMain, () => null),
+    etablissementAdditional: mapValues(endpoints.etablissementAdditional, () => null)
   }
 }
 
@@ -72,21 +72,26 @@ const getters = {
       return state.isLoading.etablissementAdditional[api]
     }
   },
-  // additionalAPIError: (state) => {
-  //   return api => {
-  //     return includes(errorCodes, state.status.etablissementAdditional[api])
-  //   }
-  // },
+  additionalAPIAvailable: (state) => {
+    return api => {
+      return state.status.etablissementAdditional[api] == 200
+    }
+  },
+  additionalAPIError: (state) => {
+    return api => {
+      return includes(errorCodes, state.status.etablissementAdditional[api])
+    }
+  },
   // additionalAPINotWorking: (state) => {
   //   return api => {
   //     return includes(badCodes, state.status.etablissementAdditional[api])
   //   }
   // },
-  // additionalAPINotFound: (state) => {
-  //   return api => {
-  //     return includes(notFoundCodes, state.status.etablissementAdditional[api])
-  //   }
-  // },
+  additionalAPINotFound: (state) => {
+    return api => {
+      return includes(notFoundCodes, state.status.etablissementAdditional[api])
+    }
+  },
 
   isWelcomeTextVisible: () => {
     if (store.state.route.name != 'Home') {
@@ -162,8 +167,8 @@ const actions = {
 }
 
 export default {
-    state,
-    mutations,
-    actions,
-    getters
+  state,
+  mutations,
+  actions,
+  getters
 }

--- a/src/store/modules/resultsAdditionalInfos.js
+++ b/src/store/modules/resultsAdditionalInfos.js
@@ -10,12 +10,6 @@ const state = {
 }
 
 const getters = {
-  RNCSAvailable: state => {
-    if (state.additionalResults['RNCS']) {
-      return true
-    }
-    return false
-  },
   RNMAvailable: state => {
     if (state.additionalResults['RNM']) {
       return true
@@ -27,6 +21,11 @@ const getters = {
       return state.additionalResults['RNCS'].dossier_entreprise_greffe_principal
     }
     return false
+  },
+  RNCSError: state => {
+    if (state.additionalResults['RNCS']) {
+      return state.additionalResults['RNCS'].error
+    }
   },
   RNMData: state => {
     if (state.additionalResults['RNM']) {
@@ -55,17 +54,13 @@ const mutations = {
 
 const actions = {
   async setResponseAdditionalInfo(dispatch, { response, api }) {
-    store.commit('setStatusAdditionalAPI', {value: response.status, endpoint: 'RNCS'})
-    if (response.status == 200) {
-      store.commit('setAdditionalInfos', { results: response.body, api: api })
-      // TEMPORARY HACK : RNM is returning 200 even in case of empty JSON.
-      // This will change soon but in the meantime we have manage this.
-      if (api == 'RNM' && response.body.ID == null) {
-        store.commit('clearAdditionalInfos', 'RNM')
-      }
-      // End of temporary hack
-    } else {
-      store.commit('clearAdditionalInfos', api)
+    store.commit('setStatusAdditionalAPI', { value: response.status, endpoint: 'RNCS' })
+    store.commit('setAdditionalInfos', { results: response.body, api: api })
+    // TEMPORARY HACK : RNM is returning 200 even in case of empty JSON.
+    // This will change soon but in the meantime we have manage this.
+    if (api == 'RNM' && response.body.ID == null) {
+      store.commit('setStatusAdditionalAPI', { value: 404, endpoint: 'RNM' })
+      store.commit('setAdditionalInfos', { results: null, api: 'RNM'})
     }
   }
 }

--- a/src/store/modules/searchAdditionalInfos.js
+++ b/src/store/modules/searchAdditionalInfos.js
@@ -27,12 +27,14 @@ const getters = {
 
 const actions = {
   // When we have an RNA ID, check if there is a Siret. If yes, look up Sirene. If no, look up the ID in Sirene.
-  fromRNARequestOtherAPIs(dispatch, id) {
+  async fromRNARequestOtherAPIs(dispatch, id) {
     if (store.getters.siretFromRNA) {
-      store.dispatch('executeSearchBySiret', { siret: store.getters.siretFromRNA, api: 'SIRENE' })
+      await store.dispatch('executeSearchBySiret', { siret: store.getters.siretFromRNA, api: 'SIRENE' })
     } else {
-      store.dispatch('executeSearchByIdAssociation', { id: id, api: 'SIRENE' })
+      await store.dispatch('executeSearchByIdAssociation', { id: id, api: 'SIRENE' })
     }
+
+    store.dispatch('searchAdditionalInfoSirene', 'RNCS')
   },
   // When we have Siret, check if there is an RNA ID. If yes, look up RNA. If no, look up Siret in RNA.
   // Also get additional RNCS and RNM Info if from SIRENE

--- a/src/store/modules/searchEtablissement.js
+++ b/src/store/modules/searchEtablissement.js
@@ -25,6 +25,7 @@ const actions = {
       case 'SIRET':
         break
       case 'SIREN':
+        await store.dispatch('searchEtablissementFromSiren', searchId)
         await store.dispatch('sendAPIRequest', process.env.BASE_ADDRESS_RNCS + searchId)
         .then(response => {
           store.dispatch('setResponseAdditionalInfo', {response: response, api: api})


### PR DESCRIPTION
# Que fait cette PR
1. Ajout de la remontée d'erreur RNCS dans le front.
2. Correction de la date de la base de donnée affichée

## Dev/commits complémentaires
Au passage j'ai nettoyé certains endroits : 
1. en dev le port attendu pour l'API RNCS devient 3002 car conflit avec SIRENE (cf [ici](https://github.com/etalab/rncs_worker_api_entreprise/pull/92/commits/7da3e952959fc93c81e687df709cc29cd57f50e2)
2. le lien vers le PDF RNCS n'est plus dupliqué (il y était à 3 endroits différents)
3. recherche des données RNCS même quand c'est un ID RNA (ça marche quand la connection RNA -> SIRENE est faite)
4. Affichage de la carte sur la page RNCS (nécessite un appel SIRENE)

# Comment faire la review
Commit par commit c'est faisable

#### Screenshot entreprise pas dans le RNCS (les données affichées proviennent de SIRENE)
![screenshot](https://screenshotscdn.firefoxusercontent.com/images/6835128a-7acc-4eda-8b4d-5c38a9270303.png)