### PR TITLE
SEO and Robots.txt

### DIFF
--- a/build/robots-options.js
+++ b/build/robots-options.js
@@ -1,0 +1,12 @@
+const productionOptions = {
+  sitemap: 'http://entreprise.data.gouv.fr/api/sirene/sitemap.xml.gz'
+}
+
+const sandboxOptions = {
+  userAgents: [{
+    name: '*',
+    disallow: ['/']
+  }]
+}
+
+module.exports = process.argv[2] == 'production' ? productionOptions : sandboxOptions

--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -8,6 +8,8 @@ var CopyWebpackPlugin = require('copy-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
+var RobotsPlugin = require('@tanepiper/robots-webpack-plugin');
+var RobotsOptions = require('./robots-options')
 
 var env = process.env.NODE_ENV === 'testing'
   ? require('../config/test.env')
@@ -95,7 +97,8 @@ var webpackConfig = merge(baseWebpackConfig, {
         to: config.build.assetsSubDirectory,
         ignore: ['.*']
       }
-    ])
+    ]),
+    new RobotsPlugin(RobotsOptions)
   ]
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -229,6 +229,12 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
+    "@tanepiper/robots-webpack-plugin": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@tanepiper/robots-webpack-plugin/-/robots-webpack-plugin-0.4.0.tgz",
+      "integrity": "sha1-Py3u5Nc+qAkSQT4/n88eRJv6qOk=",
+      "dev": true
+    },
     "@types/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "webpack-hot-middleware": "^2.21.2"
   },
   "devDependencies": {
+    "@tanepiper/robots-webpack-plugin": "^0.4.0",
     "@vue/test-utils": "^1.0.0-beta.25",
     "autoprefixer": "^7.1.2",
     "babel-core": "^6.26.3",

--- a/src/components/etablissement/EtablissementHeader.vue
+++ b/src/components/etablissement/EtablissementHeader.vue
@@ -3,7 +3,7 @@
     <div class="company__main">
       <header-skeleton v-if="isEtablissementLoading"></header-skeleton>
       <div v-else class="title__block">
-        <h2 v-if="haveSireneInfo">{{resultSirene.nom_raison_sociale | removeExtraChars}}
+        <h1 v-if="haveSireneInfo">{{resultSirene.nom_raison_sociale | removeExtraChars}}
           <span class="company__siren">(<span :inner-html.prop="resultSirene.siren | prettySirenHtml"/>)</span>
         </h1>
         <h1 v-if="haveOnlyRNAInfo">{{resultRNA.titre}} <span class="association__id">({{ resultRNA.id_association }})</span></h1>

--- a/src/components/etablissement/EtablissementHeader.vue
+++ b/src/components/etablissement/EtablissementHeader.vue
@@ -3,10 +3,10 @@
     <div class="company__main">
       <header-skeleton v-if="isEtablissementLoading"></header-skeleton>
       <div class="title__block" v-else>
-        <h2 v-if="haveSireneInfo">{{resultSirene.nom_raison_sociale | removeExtraChars}}
+        <h1 v-if="haveSireneInfo">{{resultSirene.nom_raison_sociale | removeExtraChars}}
           <span class="company__siren">(<span :inner-html.prop="resultSirene.siren | prettySirenHtml"/>)</span>
-        </h2>
-        <h2 v-if="haveOnlyRNAInfo">{{resultRNA.titre}} <span class="association__id">({{ resultRNA.id_association }})</span></h2>
+        </h1>
+        <h1 v-if="haveOnlyRNAInfo">{{resultRNA.titre}} <span class="association__id">({{ resultRNA.id_association }})</span></h1>
 
         <template v-if="haveSireneInfo">
           <div class="subtitle">

--- a/src/components/etablissement/__tests__/__snapshots__/EtablissementHeader.spec.js.snap
+++ b/src/components/etablissement/__tests__/__snapshots__/EtablissementHeader.spec.js.snap
@@ -10,7 +10,7 @@ exports[`EtablissementHeader.vue Snapshot testing It match the snapshot 1`] = `
     <div
       class="title__block"
     >
-      <h2>
+      <h1>
         
         
         <span
@@ -20,7 +20,7 @@ exports[`EtablissementHeader.vue Snapshot testing It match the snapshot 1`] = `
           <span />
           )
         </span>
-      </h2>
+      </h1>
        
       <!---->
        


### PR DESCRIPTION
## SEO
Ajout d'une balise `h1` sur toutes les pages `/etablissement` pour améliorer le référencement il doit y en avoir une et une seule.

## Robots.txt
Ajout d'un package pour générer un `robots.txt` différent en `sandbox` et en `production`.
- Sandbox : indexation par les robots désactivée
- Production : indexation activée et lien vers la sitemap 

cf PR côté back: https://github.com/etalab/sirene_as_api/pull/162