### PR TITLE
Add INPI links to RNCS web/pdf

### DIFF
--- a/src/components/etablissement/EtablissementSirene.vue
+++ b/src/components/etablissement/EtablissementSirene.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="company">
+    <etablissement-links />
+
+    <h3>Informations de la base SIRENE de l'INSEE</h3>
     <div class="company-container">
       <etablissement-sirene-contact />
       <etablissement-sirene-info />
@@ -8,12 +11,14 @@
 </template>
 
 <script>
+import EtablissementLinks from "@/components/etablissement/etablissementSirene/EtablissementLinks";
 import EtablissementSireneContact from "@/components/etablissement/etablissementSirene/EtablissementSireneContact";
 import EtablissementSireneInfo from "@/components/etablissement/etablissementSirene/EtablissementSireneInfo";
 
 export default {
   name: "EtablissementSirene",
   components: {
+    EtablissementLinks: EtablissementLinks,
     EtablissementSireneContact: EtablissementSireneContact,
     EtablissementSireneInfo: EtablissementSireneInfo
   }
@@ -21,6 +26,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+h3 {
+  margin-bottom: 0;
+}
 .company {
   margin-top: 2em;
 }

--- a/src/components/etablissement/__tests__/__snapshots__/EtablissementSirene.spec.js.snap
+++ b/src/components/etablissement/__tests__/__snapshots__/EtablissementSirene.spec.js.snap
@@ -4,6 +4,12 @@ exports[`EtablissementSirene.vue Snapshot testing It match the snapshot 1`] = `
 <div
   class="company"
 >
+  <etablissement-links-stub />
+   
+  <h3>
+    Informations de la base SIRENE de l'INSEE
+  </h3>
+   
   <div
     class="company-container"
   >

--- a/src/components/etablissement/etablissementSirene/EtablissementLinks.vue
+++ b/src/components/etablissement/etablissementSirene/EtablissementLinks.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="company-container">
+    <div class="company__panel panel">
+      <h5>
+        Fiche d'immatriculation au RNCS sur
+        <a target="_blank" href="https://data.inpi.fr">data.inpi.fr</a>
+      </h5>
+      <a
+        class="button"
+        target="_blank"
+        :href="linkInpiWeb"
+        title="Fiche d'immatriculation"
+      >
+        <img class="icon" src="@/assets/img/arrow_top_left.svg" alt="" />
+        Fiche d'immatriculation
+      </a>
+      <a
+        class="button"
+        :href="linkInpiPdf"
+        title="Télécharger la fiche d'immatriculaiton"
+      >
+        <img class="icon" src="@/assets/img/download.svg" alt="" />
+        Télécharger la fiche d'immatriculation
+      </a>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "EtablissementLinks",
+  data() {
+    return {
+      baseAddressInpi: "https://data.inpi.fr/entreprises/"
+    };
+  },
+  computed: {
+    linkInpiWeb() {
+      return `${this.baseAddressInpi}${this.$store.getters.sirenFromSirene}`;
+    },
+    linkInpiPdf() {
+      return `${this.linkInpiWeb}?format=pdf`;
+    }
+  }
+};
+</script>
+
+<style>
+.company {
+  margin-top: 2em;
+}
+
+.panel + .panel {
+  margin-left: 2em;
+}
+@media (max-width: $tablet) {
+  .panel + .panel {
+    margin-left: 0;
+  }
+}
+
+.company-container {
+  margin-bottom: 30px;
+}
+</style>


### PR DESCRIPTION
Ajout de deux liens : 
1. vers la page détaillée de l'entreprise
2. vers le PDF directement

Il est prévu d'ajouter une seconde colonne (comme pour en dessous) avec les liens RNM

![Screenshot_2020-02-27  Entreprise data gouv fr(1)](https://user-images.githubusercontent.com/5159985/75448111-48759d00-5973-11ea-8aa2-d25590016373.png)
