### PR TITLE
Maj email contact

### DIFF
--- a/src/components/__tests__/__snapshots__/ApiDoc.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/ApiDoc.spec.js.snap
@@ -35,6 +35,21 @@ exports[`ApiDoc.vue snapshot testing It match the snapshot 1`] = `
         <br />
       </p>
        
+      <p
+        class="text-center lead-text"
+      >
+        
+      Pour toutes questions :
+      
+        <a
+          href="maito:entreprise@data.gouv.fr"
+        >
+          
+        entreprise@data.gouv.fr
+      
+        </a>
+      </p>
+       
       <form
         class="text-center"
       >
@@ -353,14 +368,6 @@ exports[`ApiDoc.vue snapshot testing It match the snapshot 1`] = `
       donc reservées aux administrations ou entreprises justifiant d'une
       mission de service public.
         <br />
-        
-      Pour toutes questions :
-      
-        <a
-          href="maito:tech@entreprise.api.gouv.fr"
-        >
-          tech@entreprise.api.gouv.fr
-        </a>
       </p>
        
       <a

--- a/src/components/apiDoc/ApiDocIntro.vue
+++ b/src/components/apiDoc/ApiDocIntro.vue
@@ -13,6 +13,12 @@
         notre mailing-list pour vous tenir au courant des nouveautés et
         changements à venir.<br />
       </p>
+      <p class="text-center lead-text">
+        Pour toutes questions :
+        <a href="maito:entreprise@data.gouv.fr">
+          entreprise@data.gouv.fr
+        </a>
+      </p>
       <api-doc-mail />
     </div>
   </section>

--- a/src/components/apiDoc/ApiDocOutro.vue
+++ b/src/components/apiDoc/ApiDocOutro.vue
@@ -20,10 +20,6 @@
         <strong>Attention :</strong> Ces données ne sont pas publiques et sont
         donc reservées aux administrations ou entreprises justifiant d'une
         mission de service public.<br />
-        Pour toutes questions :
-        <a href="maito:tech@entreprise.api.gouv.fr"
-          >tech@entreprise.api.gouv.fr</a
-        >
       </p>
       <a class="button" href="https://entreprise.api.gouv.fr/"
         >Demander un accès</a


### PR DESCRIPTION
Suppression de l'e-mail de contact de API Entreprise, ça embrouille plus qu'autre chose.

Ajout d'une nouvelle adresse de contact dédiée à entreprise.data.gouv.fr

![Screenshot_2020-03-17 Documentation Entreprise data gouv fr(1)](https://user-images.githubusercontent.com/5159985/76855795-8ff89600-685a-11ea-8aa3-fa213ed70f26.png)
