### PR TITLE
Adresse sirene

### DIFF
--- a/src/components/etablissement/EtablissementMap.vue
+++ b/src/components/etablissement/EtablissementMap.vue
@@ -1,15 +1,25 @@
 <template>
-  <div v-if="haveNoMapInfo" id="map" class="panel contains-message">
-    <p class="panel__message">
-      Les données de géolocalisation ne sont pas disponibles pour cet
-      établissement.
-    </p>
-  </div>
-  <div v-else-if="mapboxglSupported" id="map" ref="map" class="panel"></div>
-  <div v-else id="map" class="panel contains-message">
-    <p class="panel__message">
-      Votre navigateur ne supporte pas WebGL et ne peut pas afficher la carte de
-      l’établissement.
+  <div class="map-container">
+    <div v-if="haveNoMapInfo" id="map" class="panel contains-message">
+      <p class="panel__message">
+        Les données de géolocalisation ne sont pas disponibles pour cet
+        établissement.
+      </p>
+    </div>
+    <div v-else-if="mapboxglSupported" id="map" ref="map" class="panel"></div>
+    <div v-else id="map" class="panel contains-message">
+      <p class="panel__message">
+        Votre navigateur ne supporte pas WebGL et ne peut pas afficher la carte
+        de l’établissement.
+      </p>
+    </div>
+    <p>
+      Géolocalisation réalisée par
+      <a href="https://etalab.gouv.fr" target="blank">Etalab</a>
+      via
+      <a href="https://adresse.data.gouv.fr/" target="blank">
+        adresse.data.gouv.fr
+      </a>
     </p>
   </div>
 </template>
@@ -100,12 +110,15 @@ export default {
 #map {
   padding: 0;
   height: 350px;
-  width: 48%;
   flex-shrink: 0;
 }
 
+.map-container {
+  width: 48%;
+}
+
 @media screen and (max-width: $desktop) {
-  #map {
+  .map-container {
     width: 100%;
   }
 }

--- a/src/components/etablissement/__tests__/__snapshots__/EtablissementMap.spec.js.snap
+++ b/src/components/etablissement/__tests__/__snapshots__/EtablissementMap.spec.js.snap
@@ -2,32 +2,86 @@
 
 exports[`EtablissementMap.vue snapshot when no webgl It match the snapshot 1`] = `
 <div
-  class="panel contains-message"
-  id="map"
+  class="map-container"
 >
-  <p
-    class="panel__message"
+  <div
+    class="panel contains-message"
+    id="map"
   >
+    <p
+      class="panel__message"
+    >
+      
+      Les données de géolocalisation ne sont pas disponibles pour cet
+      établissement.
     
-    Les données de géolocalisation ne sont pas disponibles pour cet
-    établissement.
-  
+    </p>
+  </div>
+   
+  <p>
+    
+    Géolocalisation réalisée par
+    
+    <a
+      href="https://etalab.gouv.fr"
+      target="blank"
+    >
+      Etalab
+    </a>
+    
+    via
+    
+    <a
+      href="https://adresse.data.gouv.fr/"
+      target="blank"
+    >
+      
+      adresse.data.gouv.fr
+    
+    </a>
   </p>
 </div>
 `;
 
 exports[`EtablissementMap.vue snapshot when webgl It match the snapshot 1`] = `
 <div
-  class="panel contains-message"
-  id="map"
+  class="map-container"
 >
-  <p
-    class="panel__message"
+  <div
+    class="panel contains-message"
+    id="map"
   >
+    <p
+      class="panel__message"
+    >
+      
+      Les données de géolocalisation ne sont pas disponibles pour cet
+      établissement.
     
-    Les données de géolocalisation ne sont pas disponibles pour cet
-    établissement.
-  
+    </p>
+  </div>
+   
+  <p>
+    
+    Géolocalisation réalisée par
+    
+    <a
+      href="https://etalab.gouv.fr"
+      target="blank"
+    >
+      Etalab
+    </a>
+    
+    via
+    
+    <a
+      href="https://adresse.data.gouv.fr/"
+      target="blank"
+    >
+      
+      adresse.data.gouv.fr
+    
+    </a>
   </p>
 </div>
 `;

--- a/src/components/etablissement/etablissementSirene/EtablissementSireneContact.vue
+++ b/src/components/etablissement/etablissementSirene/EtablissementSireneContact.vue
@@ -13,7 +13,7 @@
     <div class="company__item">
       <label class="company__item-key">Adresse</label>
       <div class="company__item-value">
-        {{ resultSirene.geo_l4 | ifEmptyShowPlaceholder }}
+        {{ formattedAdresse | ifEmptyShowPlaceholder }}
       </div>
     </div>
     <div class="company__item">
@@ -66,6 +66,14 @@ export default {
       const month = this.resultUniteLegale.date_creation.substring(5, 7);
       const day = this.resultUniteLegale.date_creation.substring(8, 10);
       return `${day}/${month}/${year}`;
+    },
+    formattedAdresse() {
+      var adresse_items = [
+        this.resultSirene.numero_voie,
+        this.resultSirene.type_voie,
+        this.resultSirene.libelle_voie
+      ];
+      return adresse_items.join(" ");
     }
   }
 };

--- a/src/components/etablissement/etablissementSirene/__tests__/__snapshots__/EtablissementSireneContact.spec.js.snap
+++ b/src/components/etablissement/etablissementSirene/__tests__/__snapshots__/EtablissementSireneContact.spec.js.snap
@@ -39,7 +39,7 @@ exports[`EtablissementSireneContact.vue snapshot It match the snapshot 1`] = `
       class="company__item-value"
     >
       
-      52 avenue de la fausse adresse
+        
     
     </div>
   </div>


### PR DESCRIPTION
L'adresse affichée était l'adresse géo-codé par adresse.data.gouv.fr, parfois elle est différente de celle de l'INSEE.

On affiche donc l'adresse de la base SIRENE et on ajoute une notice d'information sous la carte pour indiquer cette géolocalisation n'est pas faite par l'INSEE

![Screenshot_2020-03-17  Entreprise data gouv fr(1)](https://user-images.githubusercontent.com/5159985/76855756-77887b80-685a-11ea-98d7-d38c1d7da42b.png)
