### PR TITLE
Change beta banner and redirect to annuaire entreprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # entreprise.data.gouv.fr
 
+> **Une nouvelle version du moteur de recherche est disponible :**
+>  La nouvelle version disponible ici : [L’Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr)
+>
+>  [Repo front](https://github.com/etalab/annuaire-entreprises.data.gouv.fr)
+>  [Repo back](https://github.com/etalab/api-annuaire-entreprises)
+
 Ce site est disponible en ligne : [Entreprise.data.gouv.fr](https://entreprise.data.gouv.fr)
 
 Dans le cadre du SPD, (Service Public de la Donnée), certains jeux de données
 dont les fichiers SIRENE et RNA sont devenus publics.
 
 Le site entreprise.data.gouv.fr a pour vocation de mettre à disposition des citoyens les données ouvertes "Open-data".
+
 
 ## Exécution en local
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,14 +1,16 @@
 <template>
   <div id="app">
-    <app-header/>
-    <div class="notification full-width">
-      Ce site est un travail en cours, actuellement en beta. Vous pouvez le
-      consulter librement.
+    <app-header />
+    <div class="notification full-width notification-header">
+      🚧 Une <b>nouvelle version</b> de ce service est disponible sur
+      <a href="https://annuaire-entreprise.data.gouv.fr"
+        >annuaire-entreprise.data.gouv.fr 🐣</a
+      >
     </div>
-    <search-banner/>
+    <search-banner />
     <router-view v-if="dataFromApiAvailable"></router-view>
     <not-found v-else />
-    <app-footer/>
+    <app-footer />
   </div>
 </template>
 
@@ -19,7 +21,7 @@ import AppFooter from "@/components/layout/AppFooter";
 import NotFound from "@/components/NotFound";
 
 export default {
-  name: 'App',
+  name: "App",
 
   metaInfo: {
     title: null,
@@ -33,16 +35,21 @@ export default {
   },
 
   components: {
-    'app-header': AppHeader,
-    'search-banner': SearchBanner,
-    'app-footer': AppFooter,
-    'not-found': NotFound
+    "app-header": AppHeader,
+    "search-banner": SearchBanner,
+    "app-footer": AppFooter,
+    "not-found": NotFound
   }
-}
+};
 </script>
 
 <style lang="scss" scoped>
 #app {
   min-height: 100vh;
+}
+.notification-header {
+  font-size: 1.2rem;
+  color: #0053b3;
+  background-color: #ffcb00;
 }
 </style>


### PR DESCRIPTION
Hello @brindu 

J'ouvre cette PR, qui introduit une bannnière vers annuaire-entreprises.data.gouv.fr

Par contre ce n'est pas encore le bon moment pour merger, car la DNS n'est pas encore lié au domaine

